### PR TITLE
update Counter link to Python3 and add test cell

### DIFF
--- a/nba/NBA Player Statistics Workshop.ipynb
+++ b/nba/NBA Player Statistics Workshop.ipynb
@@ -272,7 +272,7 @@
    "cell_type": "markdown",
    "metadata": {},
    "source": [
-    "The \"DSU\" approach is a little inefficient. Instead of using a dictionary as our data type to solve the mode problem, we could use counter() from the Collections module. [Read more about counter()](https://pymotw.com/2/collections/counter.html) and try it out here:"
+    "The \"DSU\" approach is a little inefficient. Instead of using a dictionary as our data type to solve the mode problem, we could use counter() from the Collections module. [Read more about counter()](https://pymotw.com/3/collections/counter.html) and try it out here:"
    ]
   },
   {
@@ -324,6 +324,17 @@
     "    }\n",
     "\n",
     "    return stats"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {
+    "collapsed": true
+   },
+   "outputs": [],
+   "source": [
+    "print(statistics('./fixtures/nba_players.csv')) # Put in your own path here"
    ]
   },
   {
@@ -389,7 +400,7 @@
  ],
  "metadata": {
   "kernelspec": {
-   "display_name": "Python 3",
+   "display_name": "Python [default]",
    "language": "python",
    "name": "python3"
   },
@@ -403,7 +414,7 @@
    "name": "python",
    "nbconvert_exporter": "python",
    "pygments_lexer": "ipython3",
-   "version": "3.6.0"
+   "version": "3.5.3"
   }
  },
  "nbformat": 4,


### PR DESCRIPTION
On the NBA Jupyter Notebook, I updated the link to 'Read more about counter()' to the PyMOTW-3 webpage (previously it linked to the PyMOTW Python 2.7 page). 

I also added a cell under the 'Putting the pieces together' section so students can experiment with modifying the statistics() definition. This cell is already included on the Solutions branch version. 