### PR TITLE
added missing __name__ == __main__ statement in RationalNumber class

### DIFF
--- a/OOP_workshop/OOP_Workshop.ipynb
+++ b/OOP_workshop/OOP_Workshop.ipynb
@@ -21,7 +21,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 4,
+   "execution_count": 2,
    "metadata": {
     "scrolled": true
    },
@@ -85,18 +85,18 @@
     "    __repr__ = __str__\n",
     "    \n",
     "\n",
-    "    \n",
-    "# Let's create two RationalNumber variables to represent the values 1/2 and 3/2    \n",
-    "x = RationalNumber(1,2)\n",
-    "y = RationalNumber(3,2)\n",
-    "print (\"The first number is {!s}\".format(x))\n",
-    "print (\"The second number is {!s}\\n\".format(y))\n",
+    "if __name__ == \"__main__\":   \n",
+    "    # Let's create two RationalNumber variables to represent the values 1/2 and 3/2    \n",
+    "    x = RationalNumber(1,2)\n",
+    "    y = RationalNumber(3,2)\n",
+    "    print (\"The first number is {!s}\".format(x))\n",
+    "    print (\"The second number is {!s}\\n\".format(y))\n",
     "\n",
-    "# Now let's test our math operations\n",
-    "print (\"Their sum is {!s}\".format(x+y))\n",
-    "print (\"Their product is {!s}\".format(x*y))\n",
-    "print (\"Their difference is {!s}\".format(x-y))\n",
-    "print (\"Their quotient is {!s}\".format(x/y))"
+    "    # Now let's test our math operations\n",
+    "    print (\"Their sum is {!s}\".format(x+y))\n",
+    "    print (\"Their product is {!s}\".format(x*y))\n",
+    "    print (\"Their difference is {!s}\".format(x-y))\n",
+    "    print (\"Their quotient is {!s}\".format(x/y))"
    ]
   },
   {
@@ -269,7 +269,7 @@
  ],
  "metadata": {
   "kernelspec": {
-   "display_name": "Python 3 (ipykernel)",
+   "display_name": "Python 3.10.5 ('my-env')",
    "language": "python",
    "name": "python3"
   },
@@ -283,7 +283,12 @@
    "name": "python",
    "nbconvert_exporter": "python",
    "pygments_lexer": "ipython3",
-   "version": "3.10.2"
+   "version": "3.10.5"
+  },
+  "vscode": {
+   "interpreter": {
+    "hash": "d474be476f0a6db94789ad08b16ede00cb8654a4c727ed769fba79dc07ed6ebd"
+   }
   }
  },
  "nbformat": 4,


### PR DESCRIPTION
## What?
Added the missing `if __name__ == "__main__":` block around the testing code at bottom of the RationalNumber class.
## Why?
It is referenced in Part 3: Inheritance at the bottom of the notebook by the line **Now update your `__name__ == "__main__"` statement at the end of RatNum.py**.
## How?
Added missing line and indented the block below it.
## Testing?
The cell still runs from within the notebook, and it outputs the same results that it did before.